### PR TITLE
Fix "Type" Of Undefined Cache Build Error (#19)

### DIFF
--- a/src/createFileNode.js
+++ b/src/createFileNode.js
@@ -22,7 +22,10 @@ exports.createFileNode = async ({
   if (cacheMediaData) {
     fileNodeID = cacheMediaData.fileNodeID
     touchNode({
-      nodeId: cacheMediaData.fileNodeID,
+      id: cacheMediaData.fileNodeID,
+      internal: {
+        type: "DribbbleShot",
+      }
     })
   }
 


### PR DESCRIPTION
This PR adds some extra params for the `touchNode` call when fetching items from cache (details of issue can be found in #19)

I'm not super familiar with Gatsby plugins but I referenced the docs for [touchNode](https://www.gatsbyjs.com/docs/reference/config-files/actions/#touchNode) and [createNode](https://www.gatsbyjs.com/docs/reference/config-files/actions/#createNode) and it seems the params may have changed in a Gatsby update at some point.

This PR works on Gatsby `4.6.2`